### PR TITLE
fix scp target interpolation in PS script

### DIFF
--- a/pi-node-migrator.ps1
+++ b/pi-node-migrator.ps1
@@ -236,7 +236,7 @@ log "Migration du node Pi terminée avec succès"
 
     # Transférer le script via SCP
     try {
-        scp $cheminScriptLocal "$Utilisateur@$AdresseIP:~/preparation_node_pi.sh"
+        scp $cheminScriptLocal "$Utilisateur@${AdresseIP}:~/preparation_node_pi.sh"
         Afficher-Message "Script transféré avec succès sur l'hôte Debian" -Couleur Green
     } catch {
         Afficher-Message "Échec du transfert du script" -Couleur Red


### PR DESCRIPTION
Ensure the scp destination string correctly interpolates the AdresseIP variable by using ${AdresseIP} inside the double- quoted user@host expression. This prevents malformed targets when building the user@ip:~/preparation_node_pi.sh path.

Fixes #1 ??